### PR TITLE
Better performance for large amount of file changes.

### DIFF
--- a/lib/pronto/credo_runner.rb
+++ b/lib/pronto/credo_runner.rb
@@ -4,6 +4,8 @@ require 'parallel'
 
 module Pronto
   class CredoRunner < Runner
+    ELIXIR_EXTENSIONS = %w(.ex .exs).freeze
+
     def initialize(_, _)
       super
     end
@@ -50,7 +52,7 @@ module Pronto
     end
 
     def elixir_file?(path)
-      %w(.ex .exs).include?(File.extname(path))
+      ELIXIR_EXTENSIONS.include?(File.extname(path))
     end
   end
 end

--- a/lib/pronto/credo_runner.rb
+++ b/lib/pronto/credo_runner.rb
@@ -1,5 +1,6 @@
 require 'pronto'
 require 'pronto/credo/wrapper'
+require 'parallel'
 
 module Pronto
   class CredoRunner < Runner
@@ -12,9 +13,9 @@ module Pronto
 
       compile if ENV["PRONTO_CREDO_COMPILE"] == "1"
 
-      @patches.select { |p| p.additions > 0 }
+      patches = @patches.select { |p| p.additions > 0 }
         .select { |p| elixir_file?(p.new_file_full_path) }
-        .map { |p| inspect(p) }
+      Parallel.map(patches, in_threads: Parallel.processor_count) { |p| inspect(p) }
         .flatten
         .compact
     end

--- a/lib/pronto/credo_runner.rb
+++ b/lib/pronto/credo_runner.rb
@@ -15,8 +15,7 @@ module Pronto
 
       patches = @patches.select { |p| p.additions > 0 }
         .select { |p| elixir_file?(p.new_file_full_path) }
-      Parallel.map(patches, in_threads: Parallel.processor_count) { |p| inspect(p) }
-        .flatten
+      Parallel.flat_map(patches, in_threads: Parallel.processor_count) { |p| inspect(p) }
         .compact
     end
 

--- a/pronto-credo.gemspec
+++ b/pronto-credo.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.3'
 
   spec.add_runtime_dependency 'pronto', '~> 0.7', '> 0.7.0'
+  spec.add_runtime_dependency 'parallel', '~> 1.20.1'
 end


### PR DESCRIPTION
Most of the long time is in running credo serially for each file changed. This changes it to be done in parallel, making it about 2.6 times faster.